### PR TITLE
Start to ignore tar files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,11 @@
 **/fp-info-cache
 **/*-backups
 **/\~*
+
+# archives
 **/*.zip
+**/*.tar
+**/*.tar.gz
 
 # Drill and Gerber files
 **/*.gbr


### PR DESCRIPTION
This is as these are archive files that can be easily produced, but also they are in binary format and thus not easy to track and update. Thus they are better left outside of the repository.